### PR TITLE
Added ability to keep/restore previous SASL identity in userPassword attribute

### DIFF
--- a/README
+++ b/README
@@ -88,6 +88,7 @@ olcSmbKrb5PwdEnable: krb5
 olcSmbKrb5PwdMustChange: 2592012
 olcSmbKrb5PwdKrb5Realm: EDU.EXAMPLE.ORG
 olcSmbKrb5PwdRequiredClass: posixAccount
+olcSmbKrb5PwdKeepSaslIdentity: TRUE
 
 
 The overlay accepts the following configuration attributes:
@@ -103,6 +104,10 @@ The overlay accepts the following configuration attributes:
 * olcSmbKrb5PwdRequiredClass - e.g. posixAccount
   - If set, the entry needs to have this object class for the kerberos 
     principal and samba passwords to be modified
+* olcSmbKrb5PwdKeepSaslIdentity - TRUE / FALSE
+  - If set to true and if the changed password contains a SASL identity
+    ({SASL}<id>@<KERBEROS_REALM>), then smbkrb5passwd tries to restore
+    this identity after the password change.
 
 
 KERBEROS PRINCIPAL

--- a/smbkrb5pwd.c
+++ b/smbkrb5pwd.c
@@ -473,9 +473,6 @@ static int smbkrb5pwd_exop_passwd(
 		/* if this fails, do not bother with samba,
 		   because passwords should be kept in sync */
 		rc_krb5 = krb5_set_passwd(op, qpw, e, pi);
-		Log2(LDAP_DEBUG_ANY, LDAP_LEVEL_NOTICE,
-	     	     "smbkrb5pwd %s : krb5_set_passwd ret %d",
-	     	     op->o_log_prefix, rc_krb5);
 		if (rc_krb5 != LDAP_SUCCESS) {
 			rc = rc_krb5;
 			goto finish;


### PR DESCRIPTION
- Added olcSmbKrb5PwdKeepSaslIdentity option (TRUE|FALSE)
- userPassword will be restored if it contains a SASL identity and olcSmbKrb5PwdKeepSaslIdentity is TRUE
